### PR TITLE
Added deployment production ready configuration

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -4,48 +4,49 @@ metadata:
   name: {{ include "chart.fullname" . }}-controller-manager
   labels:
     control-plane: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+    {{- include "chart.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:
     matchLabels:
       control-plane: controller-manager
-    {{- include "chart.selectorLabels" . | nindent 6 }}
+      {{- include "chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         control-plane: controller-manager
-      {{- include "chart.selectorLabels" . | nindent 8 }}
+        {{- include "chart.selectorLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        {{- tpl (.Values.controllerManager.annotations | toYaml) . | nindent 8 }}
     spec:
-      containers:
-      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
-        command:
-        - /manager
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
-          | default .Chart.AppVersion }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: manager
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
-          }}
-        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
-          | nindent 10 }}
-      securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
-        8 }}
-      serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
+      securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      containers:
+        - name: manager
+          image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy }}
+          command:
+            - /manager
+          args: {{- toYaml .Values.controllerManager.manager.args | nindent 12 }}
+          env:
+            - name: KUBERNETES_CLUSTER_DOMAIN
+              value: {{ quote .Values.kubernetesClusterDomain }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 12 }}
+          securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext | nindent 12 }}
+      affinity: {{- toYaml .Values.controllerManager.affinity | nindent 8 }}
+      tolerations: {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}
+      nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}

--- a/charts/templates/leader-election-rbac.yaml
+++ b/charts/templates/leader-election-rbac.yaml
@@ -49,5 +49,5 @@ roleRef:
   name: '{{ include "chart.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "chart.fullname" . }}-controller-manager'
+  name: {{ include "chart.serviceAccountName" . | quote }}
   namespace: '{{ .Release.Namespace }}'

--- a/charts/templates/manager-rbac.yaml
+++ b/charts/templates/manager-rbac.yaml
@@ -73,5 +73,5 @@ roleRef:
   name: '{{ include "chart.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "chart.fullname" . }}-controller-manager'
+  name: {{ include "chart.serviceAccountName" . | quote }}
   namespace: '{{ .Release.Namespace }}'

--- a/charts/templates/metrics-auth-rbac.yaml
+++ b/charts/templates/metrics-auth-rbac.yaml
@@ -30,5 +30,5 @@ roleRef:
   name: '{{ include "chart.fullname" . }}-metrics-auth-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "chart.fullname" . }}-controller-manager'
+  name: {{ include "chart.serviceAccountName" . | quote }}
   namespace: '{{ .Release.Namespace }}'

--- a/charts/templates/serviceaccount.yaml
+++ b/charts/templates/serviceaccount.yaml
@@ -1,8 +1,10 @@
+{{- if .Values.controllerManager.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "chart.fullname" . }}-controller-manager
+  name: {{ include "chart.serviceAccountName" . }}
   labels:
   {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}
+    {{- tpl (toYaml .Values.controllerManager.serviceAccount.annotations) . | nindent 4 }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,17 +1,19 @@
 controllerManager:
+  replicas: 1
+  serviceAccount:
+    create: false
+    annotations: {}
+  podSecurityContext:
+    runAsNonRoot: true
   manager:
     args:
-    - --metrics-bind-address=:8443
-    - --leader-elect
-    - --health-probe-bind-address=:8081
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
+      - --metrics-bind-address=:8443
+      - --leader-elect
+      - --health-probe-bind-address=:8081
     image:
       repository: newrelic/newrelic-k8s-operator-v2
       tag: latest
+      pullPolicy: IfNotPresent
     resources:
       limits:
         cpu: 500m
@@ -19,16 +21,21 @@ controllerManager:
       requests:
         cpu: 10m
         memory: 64Mi
-  podSecurityContext:
-    runAsNonRoot: true
-  replicas: 1
-  serviceAccount:
-    annotations: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+  affinity: {}
+  tolerations: {}
+  nodeSelector: {}
+
 kubernetesClusterDomain: cluster.local
+
 metricsService:
   ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: 8443
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
   type: ClusterIP


### PR DESCRIPTION
This PR introduces production-ready configuration enhancements to the deployment setup. Below are the key changes:
- Added support for configuring affinity, tolerations, and nodeSelector to improve deployment scheduling and pod placement flexibility.
- Added the ability to include custom annotations for enhanced resource tagging and compatibility with monitoring or policy systems.
- Introduced the option to either use an existing service account or replace it with a custom-created one.

Related Issue

Fixes [newrelic/newrelic-k8s-operator-v2#14](https://github.com/newrelic/newrelic-k8s-operator-v2/issues/14#issuecomment-2577635992)